### PR TITLE
Update phpMyAdmin wget link to phpmyadmin.net

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ADD apache_default /etc/apache2/sites-available/000-default.conf
 RUN a2enmod rewrite
 
 # Configure /app folder with sample app
-RUN mkdir -p /app && rm -fr /var/www/html && ln -s /app /var/www/html
+RUN mkdir -p /app/web && rm -fr /var/www/html && ln -s /app/web /var/www/html
 ADD app/ /app
 
 #Environment variables to configure php

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM phusion/baseimage:latest
 MAINTAINER Daniel Graziotin <daniel@ineed.coffee>
+ENV REFRESHED_AT 2016-03-28
 
 # based on tutumcloud/tutum-docker-lamp
 # MAINTAINER Fernando Mayo <fernando@tutum.co>, Feng Honglin <hfeng@tutum.co>
@@ -44,9 +45,9 @@ ADD create_mysql_users.sh /create_mysql_users.sh
 RUN chmod 755 /*.sh
 
 # Add phpmyadmin
-RUN wget -O /tmp/phpmyadmin.tar.gz http://downloads.sourceforge.net/project/phpmyadmin/phpMyAdmin/4.3.12/phpMyAdmin-4.3.12-all-languages.tar.gz
+RUN wget -O /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/4.6.0/phpMyAdmin-4.6.0-all-languages.tar.gz
 RUN tar xfvz /tmp/phpmyadmin.tar.gz -C /var/www
-RUN ln -s /var/www/phpMyAdmin-4.3.12-all-languages /var/www/phpmyadmin
+RUN ln -s /var/www/phpMyAdmin-4.6.0-all-languages /var/www/phpmyadmin
 RUN mv /var/www/phpmyadmin/config.sample.inc.php /var/www/phpmyadmin/config.inc.php
 
 ENV MYSQL_PASS:-$(pwgen -s 12 1)

--- a/run.sh
+++ b/run.sh
@@ -27,6 +27,10 @@ else
     chmod -R 770 /var/run/mysqld
 fi
 
+if [ -n "$APP_DIR" ];then
+    rm -f /var/www/html && ln -s $APP_DIR /var/www/html
+fi
+
 sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
 sed -i "s/user.*/user = www-data/" /etc/mysql/my.cnf
 


### PR DESCRIPTION
phpMyAdmin is no longer hosted on sourceforge. Change link and update version. Add `ENV REFRESHED_AT 2016-03-28` to update dependancies.

Hi @dgraziotin I've enjoyed using your repo. I had to rebuild in order to serve /app/web instead of /app and found a package that is broken. I think this should fix it.

ty
